### PR TITLE
Push after build; changed default tag

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 *.tar
 ?.*
 
+.vscode
+
 # not in .gitignore
 /.git*
 /.hadolint.yaml

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,7 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 2
+
+[Makefile]
+indent_style = tab
+indent_size = 8

--- a/.github/.env
+++ b/.github/.env
@@ -1,7 +1,5 @@
 AWS_ECR_REPO=public.ecr.aws/caspiandb/debian-asdf
 AWS_REGION=us-east-1
-AWS_ROLE_ARN=arn:aws:iam::441566500427:role/workflows/github-docker-debian-asdf
+AWS_ROLE_ARN=arn:aws:iam::287737943731:role/workflows/github-workflows
 DOCKER_REPO=caspiandb/debian-asdf
 DOCKER_USERNAME=caspiandb
-IMAGE_TITLE=debian-asdf
-IMAGE_VENDOR=CaspianDB

--- a/.github/.env
+++ b/.github/.env
@@ -1,5 +1,6 @@
 AWS_ECR_REPO=public.ecr.aws/caspiandb/debian-asdf
 AWS_REGION=us-east-1
 AWS_ROLE_ARN=arn:aws:iam::287737943731:role/workflows/github-workflows
-DOCKER_REPO=caspiandb/debian-asdf
+DOCKER_REPO=docker.io/caspiandb/debian-asdf
 DOCKER_USERNAME=caspiandb
+IMAGE_NAME=debian-asdf

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,18 +3,25 @@ name: CI
 on:
   push:
     branches:
-      - "*"
+      - "**"
     paths-ignore:
-      - ".gitignore"
-      - "LICENSE"
-      - "README.md"
+      - .dockerignore
+      - .editorconfig
+      - .gitignore
+      - .hadolint.yaml
+      - .markdownlint.yaml
+      - .trunk/**
+      - LICENSE
+      - README.md
   pull_request:
     branches:
       - "main"
   workflow_dispatch:
 
 jobs:
-  docker:
+  build:
+    name: Build
+
     permissions:
       id-token: write
       contents: write
@@ -43,48 +50,48 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
 
       - name: Login to Amazon ECR Public
+        id: login-ecr
         if: github.ref == 'refs/heads/main'
         uses: aws-actions/amazon-ecr-login@v1
         with:
           registry-type: public
 
-      - name: Check latest Debian image
-        run: |
-          echo DEBIAN_TAG=$(docker run --rm gcr.io/go-containerregistry/crane ls debian | grep -P '^bullseye-[0-9]+$' | sort -r | head -n1) | tee -a $GITHUB_ENV
-
       - name: Check latest asdf release
         run: |
           echo ASDF_RELEASE=v$(curl -s https://api.github.com/repos/asdf-vm/asdf/releases | grep -oE 'tag_name": ".{1,15}",' | sed 's/tag_name\": \"v//;s/\",//' | grep -vE '^(0\.[12]\.|0\.3\.0$)' | sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}' | tail -n1) | tee -a $GITHUB_ENV
 
-      - name: Prepare new release tag
-        run: echo IMAGE_TAG=${DEBIAN_TAG}-asdf-${ASDF_RELEASE#v} | tee -a $GITHUB_ENV
+      - name: Check the base image tag
+        run: |
+          echo DEBIAN_TAG=$(docker run --rm gcr.io/go-containerregistry/crane ls debian | grep -P '^bullseye-[0-9]+$' | sort -r | head -n1) | tee -a $GITHUB_ENV
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ${{ env.DOCKER_REPO }}
-          tags: |
-            type=edge
-            type=raw,prefix=build-,value=${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-            type=sha
-            type=ref,event=branch
-            type=ref,event=pr
-          labels: |
-            org.opencontainers.image.title=${{ env.IMAGE_TITLE }}
-            org.opencontainers.image.vendor=${{ env.IMAGE_VENDOR }}
-            org.opencontainers.image.version=${{ env.IMAGE_TAG }}
+      - name: Prepare new version tag
+        run: |
+          echo VERSION=asdf-${ASDF_RELEASE#v}-${DEBIAN_TAG} | tee -a $GITHUB_ENV
+
+      - name: Prepare all image tags
+        run: |
+          echo "DOCKER_TAGS=<<END" | tee -a $GITHUB_ENV
+          cat <<END | tee -a $GITHUB_ENV
+          ${{ env.AWS_ECR_REPO }}:${VERSION}
+          ${{ env.AWS_ECR_REPO }}:asdf-${ASDF_RELEASE#v}
+          ${{ env.AWS_ECR_REPO }}:latest
+          ${{ env.DOCKER_REPO }}:${VERSION}
+          ${{ env.DOCKER_REPO }}:asdf-${ASDF_RELEASE#v}
+          ${{ env.DOCKER_REPO }}:latest
+          END
+          echo "END" | tee -a $GITHUB_ENV
 
       - name: Build and push
+        id: kaniko
         uses: int128/kaniko-action@v1
         with:
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: false
+          tags: |
+            ${{ env.DOCKER_TAGS }}
           build-args: |
             ASDF_RELEASE=${{ env.ASDF_RELEASE }}
             DEBIAN_TAG=${{ env.DEBIAN_TAG }}
+            VERSION=${{ env.VERSION }}
           kaniko-args: |
             --tarPath=/kaniko/action/output/image.tar
             --single-snapshot
@@ -96,26 +103,17 @@ jobs:
         run: docker load -i /tmp/kaniko-action-*/image.tar
 
       - name: Test built image
-        run: docker run --rm -t ${DOCKER_REPO}:edge bash -c "asdf version" | grep $ASDF_RELEASE
-
-      - name: Retag
-        if: github.ref == 'refs/heads/main'
-        run: |
-          docker tag ${DOCKER_REPO}:edge ${DOCKER_REPO}:${IMAGE_TAG}
-          docker tag ${DOCKER_REPO}:edge ${DOCKER_REPO}:latest
-          docker tag ${DOCKER_REPO}:edge ${AWS_ECR_REPO}:${IMAGE_TAG}
-          docker tag ${DOCKER_REPO}:edge ${AWS_ECR_REPO}:latest
+        run: docker run --rm -t ${AWS_ECR_REPO}:latest bash -c "asdf version" | grep $ASDF_RELEASE
 
       - name: Push
         if: github.ref == 'refs/heads/main'
         run: |
-          docker push ${DOCKER_REPO}:${IMAGE_TAG}
-          docker push ${DOCKER_REPO}:latest
-          docker push ${AWS_ECR_REPO}:${IMAGE_TAG}
-          docker push ${AWS_ECR_REPO}:latest
+          for tag in $(echo "$DOCKER_TAGS"); do
+            docker push $tag
+          done
 
       - name: Create new git tag
         if: github.ref == 'refs/heads/main'
         run: |
-          git tag -f ${IMAGE_TAG}
-          git push -f origin ${IMAGE_TAG}
+          git tag -f ${VERSION}
+          git push -f origin ${VERSION}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,26 +68,25 @@ jobs:
         run: |
           echo VERSION=asdf-${ASDF_RELEASE#v}-${DEBIAN_TAG} | tee -a $GITHUB_ENV
 
-      - name: Prepare all image tags
-        run: |
-          echo "DOCKER_TAGS=<<END" | tee -a $GITHUB_ENV
-          cat <<END | tee -a $GITHUB_ENV
-          ${{ env.AWS_ECR_REPO }}:${VERSION}
-          ${{ env.AWS_ECR_REPO }}:asdf-${ASDF_RELEASE#v}
-          ${{ env.AWS_ECR_REPO }}:latest
-          ${{ env.DOCKER_REPO }}:${VERSION}
-          ${{ env.DOCKER_REPO }}:asdf-${ASDF_RELEASE#v}
-          ${{ env.DOCKER_REPO }}:latest
-          END
-          echo "END" | tee -a $GITHUB_ENV
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          flavor: |
+            latest=true
+          images: |
+            ${{ env.AWS_ECR_REPO }}
+            ${{ env.DOCKER_REPO }}
+          tags: |
+            type=raw,value=${{ env.VERSION }}
+            type=match,prefix=asdf-,pattern=v(.*),group=1,value=${{ env.ASDF_RELEASE }}
 
       - name: Build and push
         id: kaniko
         uses: int128/kaniko-action@v1
         with:
           push: false
-          tags: |
-            ${{ env.DOCKER_TAGS }}
+          tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             ASDF_RELEASE=${{ env.ASDF_RELEASE }}
             DEBIAN_TAG=${{ env.DEBIAN_TAG }}
@@ -108,7 +107,7 @@ jobs:
       - name: Push
         if: github.ref == 'refs/heads/main'
         run: |
-          for tag in $(echo "$DOCKER_TAGS"); do
+          for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
             docker push $tag
           done
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,9 @@ jobs:
           tags: |
             type=raw,value=${{ env.VERSION }}
             type=match,prefix=asdf-,pattern=v(.*),group=1,value=${{ env.ASDF_RELEASE }}
+          labels: |
+            maintainer="CaspianDB <info@caspiandb.com>"
+            org.opencontainers.image.version=${{ env.VERSION }}
 
       - name: Build and push
         id: kaniko

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,11 @@ jobs:
       - name: Prepare environment variables
         run: cat .github/.env >> $GITHUB_ENV
 
+      - name: Enable Docker experimental features
+        run: |
+          sudo yq '.experimental=true' -i -o json /etc/docker/daemon.json
+          sudo systemctl restart docker.service
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -56,63 +61,19 @@ jobs:
         with:
           registry-type: public
 
-      - name: Check latest asdf release
-        run: |
-          echo ASDF_RELEASE=v$(curl -s https://api.github.com/repos/asdf-vm/asdf/releases | grep -oE 'tag_name": ".{1,15}",' | sed 's/tag_name\": \"v//;s/\",//' | grep -vE '^(0\.[12]\.|0\.3\.0$)' | sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}' | tail -n1) | tee -a $GITHUB_ENV
-
-      - name: Check the base image tag
-        run: |
-          echo DEBIAN_TAG=$(docker run --rm gcr.io/go-containerregistry/crane ls debian | grep -P '^bullseye-[0-9]+$' | sort -r | head -n1) | tee -a $GITHUB_ENV
-
-      - name: Prepare new version tag
-        run: |
-          echo VERSION=asdf-${ASDF_RELEASE#v}-${DEBIAN_TAG} | tee -a $GITHUB_ENV
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          flavor: |
-            latest=true
-          images: |
-            ${{ env.AWS_ECR_REPO }}
-            ${{ env.DOCKER_REPO }}
-          tags: |
-            type=raw,value=${{ env.VERSION }}
-            type=match,prefix=asdf-,pattern=v(.*),group=1,value=${{ env.ASDF_RELEASE }}
-          labels: |
-            maintainer="CaspianDB <info@caspiandb.com>"
-            org.opencontainers.image.version=${{ env.VERSION }}
-
-      - name: Build and push
-        id: kaniko
-        uses: int128/kaniko-action@v1
-        with:
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          build-args: |
-            ASDF_RELEASE=${{ env.ASDF_RELEASE }}
-            DEBIAN_TAG=${{ env.DEBIAN_TAG }}
-            VERSION=${{ env.VERSION }}
-          kaniko-args: |
-            --tarPath=/kaniko/action/output/image.tar
-            --single-snapshot
-            --skip-unused-stages
-            --snapshotMode=redo
-            --use-new-run
-
-      - name: Reuse built image
-        run: docker load -i /tmp/kaniko-action-*/image.tar
+      - name: Build
+        run: make build DOCKER_REGISTRY="${AWS_ECR_REPO}"
 
       - name: Test built image
-        run: docker run --rm -t ${AWS_ECR_REPO}:latest bash -c "asdf version" | grep $ASDF_RELEASE
+        run: docker run --rm -t ${IMAGE_NAME} bash -c "asdf version" | grep ^v
 
-      - name: Push
+      - name: Push to ECR
         if: github.ref == 'refs/heads/main'
-        run: |
-          for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
-            docker push $tag
-          done
+        run: make push DOCKER_REGISTRY="${AWS_ECR_REPO}"
+
+      - name: Push to Docker
+        if: github.ref == 'refs/heads/main'
+        run: make push DOCKER_REGISTRY="${DOCKER_REPO}"
 
       - name: Create new git tag
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/trunk.yaml
+++ b/.github/workflows/trunk.yaml
@@ -1,4 +1,4 @@
-name: Lint
+name: Trunk Check
 
 on:
   - pull_request
@@ -6,7 +6,8 @@ on:
   - workflow_dispatch
 
 jobs:
-  lint:
+  trunk:
+    name: Trunk Check
     runs-on: ubuntu-latest
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 *.tar
 ?.*
 
+.vscode
+
 # not in .dockerignore

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -3,23 +3,18 @@ runtimes:
   enabled:
     - go@1.18.3
     - node@16.14.2
-plugins:
-  sources:
-    - id: trunk
-      ref: v0.0.5
-      uri: https://github.com/trunk-io/plugins
 actions:
   enabled:
     - trunk-cache-prune
     - trunk-upgrade-available
 cli:
-  version: 0.18.1-beta
+  version: 1.1.0
 lint:
   enabled:
-    - actionlint@1.6.21
+    - actionlint@1.6.22
     - dotenv-linter@3.2.0
     - git-diff-check@SYSTEM
-    - gitleaks@8.15.0
-    - hadolint@2.10.0
+    - gitleaks@8.15.2
+    - hadolint@2.12.0
     - markdownlint@0.32.2
-    - prettier@2.7.1
+    - prettier@2.8.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 ARG ASDF_RELEASE=v0.10.2
 ARG DEBIAN_TAG=bullseye
 ARG VERSION=latest
+ARG REVISION
+ARG BUILDDATE
 
 FROM debian:${DEBIAN_TAG}
 
@@ -27,9 +29,12 @@ RUN asdf info
 
 LABEL \
   maintainer="CaspianDB <info@caspiandb.com>" \
-  org.opencontainers.image.description="Container image with asdf installer based on Debian" \
+  org.opencontainers.image.created=${BUILDDATE} \
+  org.opencontainers.image.description="Container image with Debian and asdf" \
   org.opencontainers.image.licenses="MIT" \
+  org.opencontainers.image.revision=${REVISION} \
   org.opencontainers.image.source=https://github.com/CaspianDB/docker-debian-asdf \
   org.opencontainers.image.title=debian-asdf \
+  org.opencontainers.image.url=https://github.com/CaspianDB/docker-debian-asdf \
   org.opencontainers.image.vendor=CaspianDB \
   org.opencontainers.image.version=${VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@
 
 ARG ASDF_RELEASE=v0.10.2
 ARG DEBIAN_TAG=bullseye
+ARG VERSION=latest
 
 FROM debian:${DEBIAN_TAG}
 
+ARG VERSION
 ARG ASDF_RELEASE
 
 RUN apt-get -q -y update
@@ -22,3 +24,12 @@ ENV ASDF_DIR=/root/.asdf
 ENV PATH=/root/.asdf/shims:/root/.asdf/bin:${PATH}
 
 RUN asdf info
+
+LABEL \
+  maintainer="CaspianDB <info@caspiandb.com>" \
+  org.opencontainers.image.description="Container image with asdf installer based on Debian" \
+  org.opencontainers.image.licenses="MIT" \
+  org.opencontainers.image.source=https://github.com/CaspianDB/docker-debian-asdf \
+  org.opencontainers.image.title=debian-asdf \
+  org.opencontainers.image.vendor=CaspianDB \
+  org.opencontainers.image.version=${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+ASDF_RELEASE ?= v$(shell curl -s https://api.github.com/repos/asdf-vm/asdf/releases | grep -oE 'tag_name": ".{1,15}",' | sed 's/tag_name\": \"v//;s/\",//' | grep -vE '^(0\.[12]\.|0\.3\.0$$)' | sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$$/.z/; G; s/\n/ /' | LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $$2}' | tail -n1)
+DEBIAN_TAG ?= $(shell docker run --rm gcr.io/go-containerregistry/crane ls debian | grep -P '^bullseye-[0-9]+$$' | sort -r | head -n1)
+VERSION ?= asdf-$(ASDF_RELEASE:v%=%)-$(DEBIAN_TAG)
+
+REVISION ?= $(shell git rev-parse HEAD)
+BUILDDATE ?= $(shell TZ=GMT date '+%Y-%m-%dT%R:%S.%03NZ')
+
+IMAGE_NAME ?= debian-asdf
+DOCKER_REPO ?= localhost:5000/$(IMAGE_NAME)
+
+all: build push
+
+.PHONY: build
+build: ## Build a local image without publishing artifacts.
+	$(call print-target)
+	docker build \
+	--squash \
+	--build-arg ASDF_RELEASE=$(ASDF_RELEASE) \
+	--build-arg DEBIAN_TAG=$(DEBIAN_TAG) \
+	--build-arg VERSION=$(VERSION) \
+	--build-arg REVISION=$(REVISION) \
+	--build-arg BUILDDATE=$(BUILDDATE) \
+	--tag $(IMAGE_NAME) \
+	.
+
+.PHONY: push
+push: ## Publish to container registry.
+	$(call print-target)
+	docker tag $(IMAGE_NAME) $(DOCKER_REPO):$(VERSION)
+	docker push $(IMAGE_NAME) $(DOCKER_REPO):$(VERSION)
+	docker tag $(IMAGE_NAME) $(DOCKER_REPO):asdf-$(ASDF_RELEASE:v%=%)
+	docker push $(IMAGE_NAME) $(DOCKER_REPO):asdf-$(ASDF_RELEASE:v%=%)
+	docker tag $(IMAGE_NAME) $(DOCKER_REPO):latest
+	docker push $(IMAGE_NAME) $(DOCKER_REPO):latest
+
+.PHONY: info
+info:
+	@echo "Version:           ${VERSION}"
+	@echo "Revision:          ${REVISION}"
+	@echo "Build date:        ${BUILDDATE}"
+
+.PHONY: help
+help:
+	@echo "$(IMAGE_NAME)"
+	@echo
+	@echo Targets:
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9._-]+:.*?## / {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
+define print-target
+	@printf "Executing target: \033[36m$@\033[0m\n"
+endef

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Container image with [asdf](https://asdf-vm.com/) installer based on Debian 11 "
 
 ## Tags
 
-- `asdf-X.Y.Z-bullseye-YYYYmmdd`, `latest`
+- `asdf-X.Y.Z-bullseye-YYYYmmdd`, `asdf-X.Y.Z`, `latest`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Container image with [asdf](https://asdf-vm.com/) installer based on Debian 11 "
 
 ## Tags
 
-- `bullseye-YYYYmmdd-asdf-X.Y.Z`, `latest`
+- `asdf-X.Y.Z-bullseye-YYYYmmdd`, `latest`
 
 ## Usage
 


### PR DESCRIPTION
the tags are now:

- `asdf-x.y.z`
- `asdf-x.y.z-bullseye-x.y.z`

The workflow uses `make build` which uses `docker` rather than Kaniko now.